### PR TITLE
add objectMode shorthand

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ function MultiStream (streams, opts) {
   this._next()
 }
 
+MultiStream.obj = function(streams) {
+  return new MultiStream(streams, {objectMode:true, highWaterMark:16})
+}
+
 MultiStream.prototype._read = function () {}
 
 MultiStream.prototype._next = function () {


### PR DESCRIPTION
Similar to through2 and friends this adds a `multistream.obj(...)` shorthand that enables `objectMode` and sets `highWaterMark` to something sensible in node 0.10
