### PR TITLE
Insert arrays of chunks in multistream

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ var streams = [
 MultiStream(streams).pipe(process.stdout) // => 123
 ```
 
+You can pass arrays of elements that should be inserted in final stream
+
+```js
+var streams = [
+  fs.createReadStream(__dirname + '/numbers/1.txt'),
+  ['Bird', 'bird'],
+  fs.createReadStream(__dirname + '/numbers/2.txt'),
+  function () { return ['Bird', 'is', 'the', 'word'] },
+  fs.createReadStream(__dirname + '/numbers/3.txt')
+]
+
+MultiStream(streams).pipe(process.stdout) // => 1Birdbird2birdistheword3
+```
+
 ### contributors
 
 - [Feross Aboukhadijeh](http://feross.org)

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ MultiStream.prototype._forward = function () {
 MultiStream.prototype.destroy = function (err) {
   if (this.destroyed) return
   this.destroyed = true
-  
+
   if (this._current && this._current.destroy) this._current.destroy()
   this._queue.forEach(function (stream) {
     if (stream.destroy) stream.destroy()
@@ -58,6 +58,11 @@ MultiStream.prototype._next = function () {
   var stream = this._queue.shift()
 
   if (typeof stream === 'function') stream = toStreams2(stream())
+
+  if (Array.isArray(stream)) {
+    stream.forEach(this.push, this);
+    return self._next()
+  }
 
   if (!stream) {
     this.push(null)
@@ -96,7 +101,7 @@ MultiStream.prototype._next = function () {
 }
 
 function toStreams2 (s) {
-  if (!s || typeof s === 'function' || s._readableState) return s
+  if (!s || typeof s === 'function' || s._readableState || Array.isArray(s)) return s
 
   var wrap = new stream.Readable().wrap(s)
   if (s.destroy) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -81,3 +81,19 @@ test('lazy stream creation', function (t) {
       t.end()
     }))
 })
+
+test('combine with array', function (t) {
+  var streams = [
+    ['1','2','3'],
+    ['4','5','6']
+  ]
+
+  MultiStream(streams)
+    .on('error', function (err) {
+      t.fail(err)
+    })
+    .pipe(concat(function (data) {
+      t.equal(data.toString(), '123456')
+      t.end()
+    }))
+})


### PR DESCRIPTION
This would be very useful, when you want to append/prepend some cached data.

---

Like this:

``` js
var streams = [
  fs.createReadStream(__dirname + '/numbers/1.txt'),
  ['Bird', 'bird'],
  fs.createReadStream(__dirname + '/numbers/2.txt'),
  function () { return ['Bird', 'is', 'the', 'word'] },
  fs.createReadStream(__dirname + '/numbers/3.txt')
]

MultiStream(streams).pipe(process.stdout) // => 1Birdbird2birdistheword3
```
