### PR TITLE
destroy after push(null).

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,8 +75,8 @@ MultiStream.prototype._gotNextStream = function (stream) {
   var self = this
 
   if (!stream) {
-    self.destroy()
     self.push(null)
+    self.destroy()
     return
   }
 


### PR DESCRIPTION
Arguably destroy might not be necessary? In any case, though, if you destroy before the push, you see a printed out 'premature close'