### PR TITLE
Insert HTTP(S) stream in multistream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+- 'stable'
 - '0.12'
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 #### A stream that emits multiple other streams one after another (streams2)
 
-[![Sauce Test Status](https://saucelabs.com/browser-matrix/magnet-uri.svg)](https://saucelabs.com/u/magnet-uri)
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/multistream.svg)](https://saucelabs.com/u/multistream)
 
 ![cat](https://raw.githubusercontent.com/feross/multistream/master/img.jpg)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -42,6 +42,32 @@ test('combine streams (classic)', function (t) {
   streams[2].end('3')
 })
 
+test('combine streams (http)', function (t) {
+  var streams = [
+    str('1'),
+    require('https').request('https://avatars1.githubusercontent.com/u/2401029?s=100'),
+    str('2'),
+    require('https').request('https://avatars1.githubusercontent.com/u/1024980?s=100')
+  ]
+  var i = 0
+  new MultiStream(streams)
+    .on('error', function (err) {
+      t.fail(err)
+    })
+    .on('data', function (data) {
+      i++
+      if (i === 1) {
+        t.equal(data.toString(), '1')
+      } else if (i === 3) {
+        t.equal(data.toString(), '2')
+      } else if (i === 2 || i === 4) {
+        t.ok((data[0] === 0xFF && data[1] === 0xD8 && data[2] === 0xFF), 'should be jpg') // magic number
+      }
+    }).on('end', function () {
+      t.end()
+    })
+})
+
 test('lazy stream creation', function (t) {
   var streams = [
     str('1'),


### PR DESCRIPTION
This would be very handy, for example, when you want to concat remote *.txt files.

Also it can be really helpful, when you need to send multipart/form-data with some remote and local files (it is my case).

Example:
```js
var MultiStream = require('multistream');

var streams = [
  require('https').request('https://example.com/1.txt'),
  fs.createReadStream(__dirname + '/2.txt'),
  fs.createReadStream(__dirname + '/3.txt'),
  require('https').request('https://example.com/4.txt')
];

MultiStream(streams).pipe(process.stdout) // => 1234
```