### PR TITLE
Handle stream errors on all streams

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -11,7 +11,7 @@ test('combine streams', function (t) {
     str('3')
   ]
 
-  new MultiStream(streams)
+  MultiStream(streams)
     .on('error', function (err) {
       t.fail(err)
     })
@@ -28,7 +28,7 @@ test('combine streams (classic)', function (t) {
     through()
   ]
 
-  new MultiStream(streams)
+  MultiStream(streams)
     .on('error', function (err) {
       t.fail(err)
     })
@@ -53,7 +53,7 @@ test('lazy stream creation', function (t) {
     }
   ]
 
-  new MultiStream(streams)
+  MultiStream(streams)
     .on('error', function (err) {
       t.fail(err)
     })
@@ -73,7 +73,7 @@ test('lazy stream via factory', function (t) {
     }, 0)
   }
 
-  new MultiStream(factory)
+  MultiStream(factory)
     .on('error', function (err) {
       t.fail(err)
     })
@@ -94,7 +94,7 @@ test('lazy stream via factory (factory returns error)', function (t) {
     }, 0)
   }
 
-  new MultiStream(factory)
+  MultiStream(factory)
     .on('error', function (err) {
       t.pass('got error', err)
     })
@@ -117,7 +117,7 @@ test('lazy stream via factory (classic)', function (t) {
     cb(null, s)
   }
 
-  new MultiStream(factory)
+  MultiStream(factory)
     .on('error', function (err) {
       t.fail(err)
     })
@@ -125,4 +125,19 @@ test('lazy stream via factory (classic)', function (t) {
       t.equal(data.toString(), '123')
       t.end()
     }))
+})
+
+test('throw immediate error', function (t) {
+  t.plan(1)
+
+  var streams = [
+    str('1'),
+    through() // will emit 'error'
+  ]
+
+  MultiStream(streams).on('error', function (err) {
+    t.ok(err instanceof Error, 'got expected error')
+  })
+
+  streams[1].emit('error', new Error('immediate error!'))
 })


### PR DESCRIPTION
Fix #17.

If any stream in the list emits an 'error' event, we should handle it,
even if we haven't started consuming that stream yet. Basically, we
will listen to 'error' immediately instead of at the time of use.

Previously, if any stream (other than the first, which we start
consuming right away) emitted an 'error', then it would be uncaught by
our code ("unhandled 'error' event")