### PR TITLE
Mention object-mode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var streams = [
 MultiStream(streams).pipe(process.stdout) // => 123
 ```
 
-Alternativelly, streams may be created by an asyncronous "factory" function:
+Alternatively, streams may be created by an asynchronous "factory" function:
 
 ```js
 var count = 0;

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ var streams = [
 MultiStream(streams).pipe(process.stdout) // => 123
 ```
 
+You can also create an object-mode stream with `MultiStream.obj(streams)`.
+
 To lazily create the streams, wrap them in a function:
 
 ```js


### PR DESCRIPTION
This tiny PR:

1. Adds one line mentioning `MultiStream.obj()` to README.

2. Fixes a few typos I noticed in passing.

Thanks so much for this package.  This is one of those "elemental" streams I find myself using over and over again!

Best,

K