### PR TITLE
updated the examples to "new MultiStream"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ var streams = [
   fs.createReadStream(__dirname + '/numbers/3.txt')
 ]
 
-MultiStream(streams).pipe(process.stdout) // => 123
+new MultiStream(streams).pipe(process.stdout) // => 123
 ```
 
 You can also create an object-mode stream with `MultiStream.obj(streams)`.
@@ -57,7 +57,7 @@ var streams = [
   }
 ]
 
-MultiStream(streams).pipe(process.stdout) // => 123
+new MultiStream(streams).pipe(process.stdout) // => 123
 ```
 
 Alternatively, streams may be created by an asynchronous "factory" function:
@@ -72,7 +72,7 @@ function factory (cb) {
   }, 100)
 }
 
-MultiStream(factory).pipe(process.stdout) // => 123
+new MultiStream(factory).pipe(process.stdout) // => 123
 ```
 
 ### contributors


### PR DESCRIPTION
If you ever decide in some feature to convert your script to es6 classes it would probably break others existing code that follow your examples and don't use the `new` keyword

Beside, MultiStream is a class and should also be treated as so and not as a function