### PR TITLE
Stop pushing chunks when this.push() returns false

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
+.airtap.yml
+.travis.yml
 img.jpg

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ MultiStream.prototype._forward = function () {
   this._forwarding = true
 
   var chunk
-  while ((chunk = this._current.read()) !== null) {
+  while ((chunk = this._current.read()) !== null && this._drained) {
     this._drained = this.push(chunk)
   }
 


### PR DESCRIPTION
Right now, I'm pretty sure that we'll keep calling this.push() as long as there is data from the source stream, even when this.push() returns false indicating that we should stop pushing.

cc @mafintosh Can you review this?