### PR TITLE
emit 'close' after 'end'

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,10 @@ class MultiStream extends stream.Readable {
     }
 
     if (err) this.emit('error', err)
-    this.emit('close')
+
+    process.nextTick(() => {
+      this.emit('close')
+    })
   }
 
   _next () {


### PR DESCRIPTION
Fixes an issue in node v13 (https://github.com/nodejs/node/issues/29699).

emit `'close'` in next tick in order to give `'end'` and chance to be emitted.